### PR TITLE
Support executable event file

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,8 @@ The output will be like:
 None
 [root - INFO - 2017-04-19 12:39:05,515] REPORT RequestId: b918f9ae-0ca1-44af-9937-dd5f9eeedcc1	Duration: 2.27 ms
 ```
+
+#### Dynamic events:
+
+Instead of an event.json file, any executable can be passed to `python-lambda-local` as the event path.
+In this case, it will be executed, and its stdout will be used as the event.

--- a/lambda_local/event.py
+++ b/lambda_local/event.py
@@ -4,10 +4,16 @@ Licensed under MIT.
 '''
 
 import json
+import os
+import subprocess
 
 
 def read_event(path):
-    with open(path) as event:
-        data = json.load(event)
+    if os.path.isfile(path) and os.access(path, os.X_OK):
+        r = subprocess.run(path, stdout=subprocess.PIPE)
+        data = json.loads(r.stdout)
+    else:
+        with open(path) as event:
+            data = json.load(event)
 
     return data


### PR DESCRIPTION
Instead of an event.json file, this allows any executable to be passed to `python-lambda-local` as the event path, which will be executed and its stdout used as the event.