### PR TITLE
Allow for execution on Windows, although this breaks time-out handling.

### DIFF
--- a/lambda_local/timeout.py
+++ b/lambda_local/timeout.py
@@ -15,9 +15,11 @@ class TimeoutException(Exception):
 def time_limit(seconds):
     def signal_handler(signum, frame):
         raise TimeoutException("Timeout after {} seconds.".format(seconds))
-    signal.signal(signal.SIGALRM, signal_handler)
-    signal.alarm(seconds)
+    if hasattr(signal, "SIGALRM"):
+        signal.signal(signal.SIGALRM, signal_handler)
+        signal.alarm(seconds)
     try:
         yield
     finally:
-        signal.alarm(0)
+        if hasattr(signal, "SIGALRM"):
+            signal.alarm(0)


### PR DESCRIPTION
by checking if SIGALRM exists we can determine if it is either running on UNIX or Windows. If it is running on Windows, ignore the timeout feature and just continue.