### PR TITLE
added an option to set env vars using json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ optional arguments:
                         ARN string for lambda function
   -v VERSION_NAME, --version-name VERSION_NAME
                         lambda function version name
+  -e ENVIRONMENT_VARIABLES, --environment-variables ENVIRONMENT_VARIABLES
+                        path to flat json file with environment variables
   --version             print the version of python-lambda-local and exit
 ```
 

--- a/lambda_local/__init__.py
+++ b/lambda_local/__init__.py
@@ -49,6 +49,9 @@ default: 3")
     parser.add_argument("-v", "--version-name", metavar="VERSION_NAME",
                         type=str, default="",
                         help="lambda function version name")
+    parser.add_argument("-e", "--environment-variables",
+                        metavar="ENVIRONMENT_VARIABLES", type=str,
+                        help="path to flat json file with environment variables")
 
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + __version__,

--- a/lambda_local/environment_variables.py
+++ b/lambda_local/environment_variables.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+
+def set_environment_variables(json_file_path):
+    """
+    Read and set environment variables from a flat json file.
+
+    Bear in mind that env vars set this way and later on read using
+    `os.getenv` function will be strings since after all env vars are just
+    that - plain strings.
+
+    Json file example:
+    ```
+    {
+        "FOO": "bar",
+        "BAZ": true
+    }
+    ```
+
+    :param json_file_path: path to flat json file
+    :type json_file_path: str
+    """
+    if json_file_path:
+        with open(json_file_path) as json_file:
+            env_vars = json.loads(json_file.read())
+
+            for env_name, env_value in env_vars.items():
+                os.environ[str(env_name)] = str(env_value)

--- a/lambda_local/main.py
+++ b/lambda_local/main.py
@@ -15,6 +15,7 @@ from botocore.vendored.requests.packages import urllib3
 
 from . import event
 from . import context
+from .environment_variables import set_environment_variables
 from .timeout import time_limit
 from .timeout import TimeoutException
 
@@ -31,6 +32,9 @@ EXITCODE_ERR = 1
 
 
 def run(args):
+    # set env vars if path to json file was given
+    set_environment_variables(args.environment_variables)
+
     e = event.read_event(args.event)
     c = context.Context(args.timeout, args.arn_string, args.version_name)
     if args.library is not None:

--- a/tests/environment_variables.json
+++ b/tests/environment_variables.json
@@ -1,0 +1,5 @@
+{
+    "STR_KEY": "foo",
+    "INT_KEY": 100,
+    "BOOL_KEY": false
+}

--- a/tests/test_environment_variables.py
+++ b/tests/test_environment_variables.py
@@ -1,0 +1,15 @@
+import os
+
+from lambda_local.environment_variables import set_environment_variables
+
+
+def test_set_environment_variables():
+    os.getenv('STR_KEY') is None
+    os.getenv('INT_KEY') is None
+    os.getenv('BOOL_KEY') is None
+
+    set_environment_variables('tests/environment_variables.json')
+
+    assert os.getenv('STR_KEY') == 'foo'
+    assert os.getenv('INT_KEY') == '100'
+    assert os.getenv('BOOL_KEY') == 'False'


### PR DESCRIPTION
It's useful for the developer to be able to add some environment variables during local execution.

The simplest way to implement this and keep it reusable is to just have the env vars in a flat json file and load them if python-lambda-local cli was given optional argument.