### PR TITLE
Add timer timeout implementation for windows.

### DIFF
--- a/lambda_local/timeout.py
+++ b/lambda_local/timeout.py
@@ -4,7 +4,9 @@ Licensed under MIT.
 '''
 
 import signal
+import threading
 from contextlib import contextmanager
+from six.moves import _thread
 
 
 class TimeoutException(Exception):
@@ -13,11 +15,21 @@ class TimeoutException(Exception):
 
 @contextmanager
 def time_limit(seconds):
-    def signal_handler(signum, frame):
-        raise TimeoutException("Timeout after {} seconds.".format(seconds))
-    signal.signal(signal.SIGALRM, signal_handler)
-    signal.alarm(seconds)
-    try:
-        yield
-    finally:
-        signal.alarm(0)
+    if hasattr(signal, "SIGALRM"):
+        def signal_handler(signum, frame):
+            raise TimeoutException("Timeout after {} seconds.".format(seconds))
+        signal.signal(signal.SIGALRM, signal_handler)
+        signal.alarm(seconds)
+        try:
+            yield
+        finally:
+            signal.alarm(0)
+    else:
+        timer = threading.Timer(seconds, lambda: _thread.interrupt_main())
+        timer.start()
+        try:
+            yield
+        except KeyboardInterrupt:
+            raise TimeoutException("Timeout after {} seconds.".format(seconds))
+        finally:
+            timer.cancel()


### PR DESCRIPTION
There are limitations on timer's implementation.

See: https://docs.python.org/3/library/_thread.html