### PR TITLE
Handle exceptions by using traceback.format_exc instead of extract_tb

### DIFF
--- a/lambda_local/main.py
+++ b/lambda_local/main.py
@@ -124,7 +124,7 @@ def execute(func, event, context):
         err = sys.exc_info()
         result = json.dumps({
             "errorMessage": str(err[1]),
-            "stackTrace": traceback.format_exc(),
+            "stackTrace": traceback.format_tb(err[2]),
             "errorType": err[0].__name__
         }, indent=4, separators=(',', ': '))
         err_type = ERR_TYPE_EXCEPTION

--- a/lambda_local/main.py
+++ b/lambda_local/main.py
@@ -124,7 +124,7 @@ def execute(func, event, context):
         err = sys.exc_info()
         result = json.dumps({
             "errorMessage": str(err[1]),
-            "stackTrace": traceback.extract_tb(err[2]),
+            "stackTrace": traceback.format_exc(),
             "errorType": err[0].__name__
         }, indent=4, separators=(',', ': '))
         err_type = ERR_TYPE_EXCEPTION

--- a/tests/test_direct_invocations.py
+++ b/tests/test_direct_invocations.py
@@ -63,3 +63,26 @@ def test_check_command_line():
 
     os.remove(request_file)
     assert p.exitcode == 0
+
+
+def test_check_command_line_error():
+    request = json.dumps({})
+    request_file = 'check_command_line_event.json'
+    with open(request_file, "w") as f:
+        f.write(request)
+
+    args = argparse.Namespace(event=request_file,
+                              file='tests/test_direct_invocations.py',
+                              function='my_failing_lambda_function',
+                              timeout=1,
+                              environment_variables='',
+                              library=None,
+                              version_name='',
+                              arn_string=''
+                              )
+    p = Process(target=lambda_run, args=(args,))
+    p.start()
+    p.join()
+
+    os.remove(request_file)
+    assert p.exitcode == 1

--- a/tests/test_direct_invocations.py
+++ b/tests/test_direct_invocations.py
@@ -1,5 +1,5 @@
 '''
-python-lambda-local: Test Direct Inovactions 
+python-lambda-local: Test Direct Invocations
 (command-line and direct).
 
 Meant for use with py.test.
@@ -13,12 +13,17 @@ from multiprocessing import Process
 import os
 from lambda_local.main import run as lambda_run
 from lambda_local.main import call as lambda_call
+from lambda_local.main import ERR_TYPE_EXCEPTION
 from lambda_local.context import Context
 
 
 def my_lambda_function(event, context):
     print("Hello World from My Lambda Function!")
     return 42
+
+
+def my_failing_lambda_function(event, context):
+    raise Exception('Oh no')
 
 
 def test_function_call_for_pytest():
@@ -28,6 +33,13 @@ def test_function_call_for_pytest():
     assert error_type is None
 
     assert result == 42
+
+
+def test_handle_exceptions_gracefully():
+    (result, error_type) = lambda_call(
+        my_failing_lambda_function, {}, Context(1))
+
+    assert error_type is ERR_TYPE_EXCEPTION
 
 
 def test_check_command_line():


### PR DESCRIPTION
This fixes #57, where we were seeing `TypeError: Object of type FrameSummary is not JSON serializable` if the handler function throws an exception.

`traceback.format_exc` returns a string that can be easily turned into JSON.