### PR TITLE
Adds verbose flag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run `python-lambda-local -h` to see the help.
 ```
 usage: python-lambda-local [-h] [-l LIBRARY_PATH] [-f HANDLER_FUNCTION]
                            [-t TIMEOUT] [-a ARN_STRING] [-v VERSION_NAME]
-                           [-e ENVIRONMENT_VARIABLES] [--version]
+                           [-e ENVIRONMENT_VARIABLES] [--version] [--verbose]
                            FILE EVENT
 
 Run AWS Lambda function written in Python on local machine.
@@ -52,6 +52,8 @@ optional arguments:
   -e ENVIRONMENT_VARIABLES, --environment-variables ENVIRONMENT_VARIABLES
                         path to flat json file with environment variables
   --version             print the version of python-lambda-local and exit
+  --verbose             print all logging information. when not provided,
+                        truncated logs will print
 ```
 
 ### Prepare development directory
@@ -119,7 +121,7 @@ The output will be like:
 
 ```
 [root - INFO - 2018-11-20 17:10:53,352] Event: {'answer': 42}
-[root - INFO - 2018-11-20 17:10:53,352] START RequestId: 3c8e6db4-886a-43da-a1c7-5e6f715de531 Version: 
+[root - INFO - 2018-11-20 17:10:53,352] START RequestId: 3c8e6db4-886a-43da-a1c7-5e6f715de531 Version:
 0
 49
 196

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ None
 ### API signature
 
 ``` python
-call(func, event, context, environment_variables={})
+call(func, event, context, environment_variables={}, verbose=True)
 ```
 
 Call a handler function `func` with given `event`, `context` and custom `environment_variables`.
@@ -164,6 +164,7 @@ event = {
     "answer": 42
 }
 context = Context(5)
+
 
 call(test.handler, event, context)
 ```

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Run ``python-lambda-local -h`` to see the help.
 
    usage: python-lambda-local [-h] [-l LIBRARY_PATH] [-f HANDLER_FUNCTION]
                               [-t TIMEOUT] [-a ARN_STRING] [-v VERSION_NAME]
-                              [-e ENVIRONMENT_VARIABLES] [--version]
+                              [-e ENVIRONMENT_VARIABLES] [--version] [--verbose]
                               FILE EVENT
 
    Run AWS Lambda function written in Python on local machine.
@@ -57,6 +57,8 @@ Run ``python-lambda-local -h`` to see the help.
      -e ENVIRONMENT_VARIABLES, --environment-variables ENVIRONMENT_VARIABLES
                            path to flat json file with environment variables
      --version             print the version of python-lambda-local and exit
+     --verbose             print all logging information. when not provided,
+                           truncated logs will print
 
 Prepare development directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ API signature
 
 .. code:: python
 
-   call(func, event, context, environment_variables={})
+   call(func, event, context, environment_variables={}, verbose=True)
 
 Call a handler function ``func`` with given ``event``, ``context`` and
 custom ``environment_variables``.

--- a/lambda_local/__init__.py
+++ b/lambda_local/__init__.py
@@ -48,6 +48,9 @@ default: 3")
     parser.add_argument("--version", action="version",
                         version="%(prog)s " + __version__,
                         help="print the version of python-lambda-local and exit")
+    parser.add_argument("--verbose", action='store_true', help="print all logging information. \
+                        when not provided, truncated logs will print")
+
 
     return parser.parse_args()
 

--- a/lambda_local/main.py
+++ b/lambda_local/main.py
@@ -17,9 +17,13 @@ from .environment_variables import set_environment_variables, export_variables
 from .timeout import time_limit
 from .timeout import TimeoutException
 
-logging.basicConfig(stream=sys.stdout,
-                    level=logging.INFO,
-                    format='[%(name)s - %(levelname)s - %(asctime)s] %(message)s')
+def set_logger_config(verbose):
+    format = '%(message)s'
+    if verbose:
+        format = '[%(name)s - %(levelname)s - %(asctime)s] %(message)s'
+    logging.basicConfig(stream=sys.stdout,
+                        level=logging.INFO,
+                        format=format)
 
 
 ERR_TYPE_EXCEPTION = 0
@@ -44,11 +48,14 @@ class FunctionLoader():
                  source=None,
                  function_name=None,
                  library_path=None,
+                 verbose=None,
+
                  func=None):
         self.request_id = request_id
         self.source = source
         self.function_name = function_name
         self.library_path = library_path
+        self.verbose = verbose
 
         self.func = func
 
@@ -69,6 +76,8 @@ def call(func, event, context, environment_variables={}):
 def run(args):
     # set env vars if path to json file was given
     set_environment_variables(args.environment_variables)
+    # Sets the logger format based on the verbose option
+    set_logger_config(args.verbose)
 
     e = event.read_event(args.event)
     c = context.Context(
@@ -79,7 +88,9 @@ def run(args):
         request_id=c.aws_request_id,
         source=args.file,
         function_name=args.function,
-        library_path=args.library)
+        library_path=args.library,
+        verbose=args.verbose,
+        )
 
     (result, err_type) = _runner(loader, e, c)
 
@@ -91,8 +102,9 @@ def _runner(loader, event, context):
     logger = logging.getLogger()
 
     logger.info("Event: {}".format(event))
-    logger.info("START RequestId: {} Version: {}".format(
-        context.aws_request_id, context.function_version))
+    if loader.verbose:
+        logger.info("START RequestId: {} Version: {}".format(
+            context.aws_request_id, context.function_version))
 
     queue = multiprocessing.Queue()
     p = multiprocessing.Process(
@@ -102,14 +114,20 @@ def _runner(loader, event, context):
     (result, err_type, duration) = queue.get()
     p.join()
 
-    logger.info("END RequestId: {}".format(context.aws_request_id))
+    if loader.verbose:
+        logger.info("END RequestId: {}".format(context.aws_request_id))
     duration = "{0:.2f} ms".format(duration)
-    logger.info("REPORT RequestId: {}\tDuration: {}".format(
-        context.aws_request_id, duration))
-    if type(result) is TimeoutException:
-        logger.error("RESULT:\n{}".format(result))
+
+    if loader.verbose:
+        logger.info("REPORT RequestId: {}\tDuration: {}".format(
+            context.aws_request_id, duration))
     else:
-        logger.info("RESULT:\n{}".format(result))
+        logger.info("Duration: {}".format(duration))
+
+    if type(result) is TimeoutException:
+        logger.error("Result: {}".format(result))
+    else:
+        logger.info("Result: {}".format(result))
 
     return (result, err_type)
 

--- a/lambda_local/main.py
+++ b/lambda_local/main.py
@@ -67,9 +67,11 @@ class FunctionLoader():
             self.request_id, self.source, self.function_name)
 
 
-def call(func, event, context, environment_variables={}):
+def call(func, event, context, environment_variables={}, verbose=True):
     export_variables(environment_variables)
-    loader = FunctionLoader(func=func)
+    loader = FunctionLoader(func=func, verbose=verbose)
+    # Sets the logger format based on the verbose option
+    set_logger_config(verbose)
     return _runner(loader, event, context)
 
 

--- a/tests/test_direct_invocations.py
+++ b/tests/test_direct_invocations.py
@@ -55,7 +55,8 @@ def test_check_command_line():
                               environment_variables='',
                               library=None,
                               version_name='',
-                              arn_string=''
+                              arn_string='',
+                              verbose=True,
                               )
     p = Process(target=lambda_run, args=(args,))
     p.start()
@@ -78,7 +79,8 @@ def test_check_command_line_error():
                               environment_variables='',
                               library=None,
                               version_name='',
-                              arn_string=''
+                              arn_string='',
+                              verbose=True,
                               )
     p = Process(target=lambda_run, args=(args,))
     p.start()


### PR DESCRIPTION
The output from this is as follows:

```
Event: {'event': 42}
Duration: 0.68 ms
Result: hello from lambda
```

We of course can revert this-- the main change is how `RESULT` is formatted.

Resolves #68