### PR TITLE
Add __main__ file for using the package as a module

### DIFF
--- a/lambda_local/__main__.py
+++ b/lambda_local/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added `__main__` that operates the same way as `__init__`, but allows the package to be called directly as a module

Resolves #75 