### PR TITLE
Update `__init__` to deal with outdated `pkg_resources` package for newer versions of python

### DIFF
--- a/lambda_local/__init__.py
+++ b/lambda_local/__init__.py
@@ -7,12 +7,11 @@ Licensed under MIT.
 
 from __future__ import print_function
 import argparse
-import pkg_resources
+import importlib.metadata
 
 from .main import run
 
-__version__ = pkg_resources.require("python-lambda-local")[0].version
-
+__version__ = importlib.metadata.version("python-lambda-local")
 
 def main():
     args = parse_args()

--- a/lambda_local/__init__.py
+++ b/lambda_local/__init__.py
@@ -7,11 +7,19 @@ Licensed under MIT.
 
 from __future__ import print_function
 import argparse
-import importlib.metadata
+
+# Get the version of python-lambda-local
+try:
+    from importlib.metadata import version as get_version
+    __version__ = get_version("python-lambda-local")
+
+# If importlib.metadata is not available, use pkg_resources (older versions of Python)
+except ImportError:
+    from pkg_resources import require
+    __version__ = require("python-lambda-local")[0].version
 
 from .main import run
 
-__version__ = importlib.metadata.version("python-lambda-local")
 
 def main():
     args = parse_args()


### PR DESCRIPTION
Hi 👋 

Not sure if this is still maintained, but wondering if anyone could look at this. `pkg_resources`, which is imported in the init to get the `__version__`, is deprecated. Using `importlib` would solve the issue, I believe. That would make the package compatible with newer versions of python (3.12 and up).

Ran the tests, all green (but not sure how thorough they are).

Thanks!